### PR TITLE
Remove "social_steam: test"

### DIFF
--- a/chalk.yaml
+++ b/chalk.yaml
@@ -3,4 +3,3 @@ blog_theme: light
 dropdown:
   enabled: true
 scrollappear_enabled: true
-social_steam: test


### PR DESCRIPTION
Removing "social_steam: test" from the chalk.yaml file to avoid the persistent steam social icon issue. Given that Grab will store user specific settings for the social icons in user/config/themes/chalk.yaml, lets get rid of this hard coded value.