### PR TITLE
Fix issue with theme not render correctly, using raw to render html

### DIFF
--- a/templates/default.html.twig
+++ b/templates/default.html.twig
@@ -6,7 +6,7 @@
         {% include 'partials/navigation.html.twig' %}
           <section id="body">
             <div class="wrapper padding">
-               {{ page.content }}
+               {{ page.content | raw }}
             </div>
           </section>
 

--- a/templates/error.html.twig
+++ b/templates/error.html.twig
@@ -3,6 +3,6 @@
 {% block content %}
     <div class="lead text-center">
         <h1>Error!</h1>
-        {{ page.content }}
+        {{ page.content | raw }}
     </div>
 {% endblock %}

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -22,7 +22,7 @@
     {% endif %}
         {% do assets.addCss('https://cdnjs.cloudflare.com/ajax/libs/fluidbox/2.0.5/css/fluidbox.min.css', 98) %}
     {% endblock %}
-    {{ assets.css() }}
+    {{ assets.css() | raw }}
 
 {% endblock head%}
 </head>
@@ -58,7 +58,7 @@
     {% do assets.addJs('theme://js/application.js', 100) %}
     
 {% endblock %}
-{{ assets.js() }}
+{{ assets.js() | raw }}
 
 </body>
 </html>

--- a/templates/partials/footer.html.twig
+++ b/templates/partials/footer.html.twig
@@ -260,6 +260,6 @@
     {% endif %}
   </ul>
    <p>
-   {{ theme_config.footer_text }}
+   {{ theme_config.footer_text | raw }}
   </p>
 </footer>

--- a/templates/post.html.twig
+++ b/templates/post.html.twig
@@ -26,7 +26,7 @@
           </header>
 
           <div class="article-content">
-            {{ content }}
+            {{ content | raw }}
           </div>
           <div class="article-share">
             

--- a/templates/tags.html.twig
+++ b/templates/tags.html.twig
@@ -7,7 +7,7 @@
           <section id="body">
             <div class="wrapper padding">
                 <h1 style="text-align: center;padding-top:100px; padding-bottom:80px;"><i class="fa fa-hashtag"></i>tags</h1>
-               {{ page.content }}
+               {{ page.content | raw }}
                {% include 'partials/taxonomylist.html.twig' with {route_url: my_url, taxonomy: 'tag'} %}
 
             </div>


### PR DESCRIPTION
Chalk theme is not compatible with Grav v1.7.24
By allowing raw content in template, I was able to fix the issue.