### PR TITLE
article.summary in RAW format(blog_listing.html.twig)

### DIFF
--- a/templates/blog_listing.html.twig
+++ b/templates/blog_listing.html.twig
@@ -27,7 +27,7 @@
                 </div>
                 {% if theme_config.summary_enabled == "on" %}
                 <a href="{{ article.url }}" title="{{article.title}}">
-                    <p>{{article.summary}}</p>
+                    <p>{{article.summary|raw}}</p>
                 </a>
             {% endif %}
         	</li>


### PR DESCRIPTION
Show {{article.summary}} in RAW format, without encoded HTML tags